### PR TITLE
chore: we actually want to emphasise this

### DIFF
--- a/source/_patterns/icons/_icons.demonstration.scss
+++ b/source/_patterns/icons/_icons.demonstration.scss
@@ -1,4 +1,4 @@
-.do-not-copy-this-class-example-icon-list {
+.DO-NOT-COPY-THIS-CLASS-example-icon-list {
 	&,
 	ul {
 		list-style: none;
@@ -11,11 +11,11 @@
 		flex-wrap: wrap;
 		justify-content: center;
 
-		.do-not-copy-this-class-example-bg-variants-regular,
-		.do-not-copy-this-class-example-bg-variants-dark {
+		.DO-NOT-COPY-THIS-CLASS-example-bg-variants-regular,
+		.DO-NOT-COPY-THIS-CLASS-example-bg-variants-dark {
 			min-width: 250px;
 		}
-		.do-not-copy-this-class-example-bg-variants-regular {
+		.DO-NOT-COPY-THIS-CLASS-example-bg-variants-regular {
 			ul {
 				justify-content: flex-end;
 			}
@@ -40,21 +40,21 @@
 
 			color: $db-color-cool-gray-700;
 
-			&.do-not-copy-this-class-example-bg-variants-turquoise {
+			&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-turquoise {
 				background-color: $db-color-turquoise-400;
 			}
-			&.do-not-copy-this-class-example-bg-variants-red {
+			&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-red {
 				background-color: $db-color-red-500;
 
 				--db-icon-color: #fff;
 				--db-icon-pulse-color: #fff;
 			}
-			&.do-not-copy-this-class-example-bg-variants-cyan {
+			&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-cyan {
 				background-color: $db-color-cyan-200;
 
 				--db-icon-pulse-color: currentColor;
 			}
-			&.do-not-copy-this-class-example-bg-variants-dark {
+			&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-dark {
 				background-color: #272d37; // TODO: richtige Farbvariable raus suchen
 
 				--db-icon-color: #fff;

--- a/source/_patterns/icons/functional/functional-icons.hbs
+++ b/source/_patterns/icons/functional/functional-icons.hbs
@@ -1,8 +1,8 @@
-<ul class="do-not-copy-this-class-example-icon-list icons functional">
+<ul class="DO-NOT-COPY-THIS-CLASS-example-icon-list icons functional">
 	{{#each icons }}<li>
 		<ul>
 			{{#each @root.example-bgs }}
-				<li class="do-not-copy-this-class-example-bg-variants-{{ variant }}">
+				<li class="DO-NOT-COPY-THIS-CLASS-example-bg-variants-{{ variant }}">
 					<ul>
 						{{#each ../variants }}
 						{{#if_eq @root.category "transportation"}}

--- a/source/_patterns/icons/illustrative/illustrative-icons.hbs
+++ b/source/_patterns/icons/illustrative/illustrative-icons.hbs
@@ -1,8 +1,8 @@
-<ul class="do-not-copy-this-class-example-icon-list icons illustrative">
+<ul class="DO-NOT-COPY-THIS-CLASS-example-icon-list icons illustrative">
 	{{#each icons }}<li>
 		<ul>
 			{{#each @root.example-bgs }}
-				<li class="do-not-copy-this-class-example-bg-variants-{{ variant }}">
+				<li class="DO-NOT-COPY-THIS-CLASS-example-bg-variants-{{ variant }}">
 					<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" aria-hidden="true">
 						<use href="../../icons/illustrative/{{ @root.category }}/db_ic_il_{{ ../icon }}.svg#icon"></use>
 					</svg>

--- a/source/_patterns/logo/_logo.demonstration.scss
+++ b/source/_patterns/logo/_logo.demonstration.scss
@@ -1,4 +1,4 @@
-.do-not-copy-this-class-example-logo-list {
+.DO-NOT-COPY-THIS-CLASS-example-logo-list {
 	list-style: none;
 
 	padding-left: 0;
@@ -15,15 +15,15 @@
 
 		color: $db-color-cool-gray-700;
 
-		&.do-not-copy-this-class-example-bg-variants-cool-gray {
+		&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-cool-gray {
 			background-color: $db-color-cool-gray-100;
 		}
-		&.do-not-copy-this-class-example-bg-variants-red {
+		&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-red {
 			background-color: $db-color-red-500;
 
 			--db-logo-color: #{$db-color-white};
 		}
-		&.do-not-copy-this-class-example-bg-variants-image {
+		&.DO-NOT-COPY-THIS-CLASS-example-bg-variants-image {
 			background-image: url(https://marketingportal.extranet.deutschebahn.com/sites/default/files/2021-12-13/Ausn01.png);
 			background-repeat: no-repeat;
 			background-size: cover;

--- a/source/_patterns/logo/logo.hbs
+++ b/source/_patterns/logo/logo.hbs
@@ -1,6 +1,6 @@
-<ul class="do-not-copy-this-class-example-logo-list">
+<ul class="DO-NOT-COPY-THIS-CLASS-example-logo-list">
 	{{#each example-bgs }}
-		<li class="do-not-copy-this-class-example-bg-variants-{{ variant }}">
+		<li class="DO-NOT-COPY-THIS-CLASS-example-bg-variants-{{ variant }}">
 			<svg xmlns="http://www.w3.org/2000/svg" width="80" height="56" aria-hidden="true">
 				<use href="../../images/db_logo.svg#logo"></use>
 			</svg>


### PR DESCRIPTION
In the past some people even tried to copy these classes, that aren't meant to get distributed, mainly because we've focused solely on providing this via SCSS. We're currently shifting to partly providing some of these as utility classes as well, but until then it might be better to enforce the recognition of a _not-to-copy_-class.