### PR TITLE
fix: corrected that demo images height

### DIFF
--- a/source/_patterns/logo/_logo.demonstration.scss
+++ b/source/_patterns/logo/_logo.demonstration.scss
@@ -34,7 +34,7 @@
 			padding-left: 37px;
 
 			width: 600px;
-			height: 358px;
+			height: 340px;
 
 			--db-logo-backgroundcolor: #{$db-color-white};
 		}


### PR DESCRIPTION
The referenced image by the Marketingportal on the [logo example page](https://db-ui.github.io/base/?p=logo-logo) has changed dimensions - therefor we need to correct it.