### PR TITLE
fix(pipeline): deploy step

### DIFF
--- a/.github/scripts/build-gh-page.sh
+++ b/.github/scripts/build-gh-page.sh
@@ -16,7 +16,7 @@ fi
 
 
 echo "📥 Get gh-pages tar"
-curl -L https://github.com/"$OWNER_NAME"/"$REPO_NAME"/tarball/gh-pages --output gh-pages
+curl -L https://github.com/db-ui/base/tarball/gh-pages --output gh-pages
 
 echo "📦 Unpack Tar"
 if [[ $RELEASE == "true" ]]; then


### PR DESCRIPTION
Migrated too much stuff for the pipeline fix, resulting in that `deploy` doesn't work anymore.