### PR TITLE
refactor: validate for default GH branch names

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "xo": "^0.52.4"
   },
   "validate-branch-name": {
-    "pattern": "((dependabot-)|^((test|feat|fix|chore|docs|refactor|style|ci|perf)\\-[a-zA-Z0-9\\-]+)$)",
+    "pattern": "((dependabot-)|^((test|feat|fix|chore|docs|refactor|style|ci|perf|[0-9]+)\\-[a-zA-Z0-9\\-]+)$)",
     "errorMsg": "There is something wrong with your branch name. You should rename your branch to a valid name and try again. See the Pattern below."
   },
   "repository": {


### PR DESCRIPTION
If a branch is being created for an issue through the GitHub UI, its branch name is starting with the issues number followed by the text. We should ensure that we even also support this within our branch name validation script.

adapted from https://github.com/db-ui/core/pull/139