### PR TITLE
refactor(ci/cd): better sync the update timeframes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "03:00"
+      time: "04:00"
       timezone: "Europe/Berlin"
     pull-request-branch-name:
       separator: "-"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -3,7 +3,7 @@ name: Schedule Auto Update
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "30 4 * * *"
 
 jobs:
   auto-update:


### PR DESCRIPTION
we'd like to better sync the timeframes for updating both our dependencies as well as our Guidelines 3.0 branch. This is both about increasing the dependabot time slightly towards working hours, but even also doing the update to `dbux-3` branch afterwards and not previously.

see also https://github.com/db-ui/core/pull/225 and https://github.com/db-ui/elements/pull/688