### PR TITLE
refactor: not installing plugins for husky npx

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -3,4 +3,4 @@
 # shellcheck source=./_/husky.sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --yes commitlint --edit "$1"
+npx --no commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # shellcheck disable=SC1091
 # shellcheck source=./_/husky.sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx --no commitlint --edit "$1"
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,6 @@
 echo "### validate branch name ###"
 npx validate-branch-name
 echo "### lint staged files ###"
-npx lint-staged
+npx lint-staged --no
 echo "### check for commit mail ###"
 node ./scripts/check-commit-mail.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # shellcheck disable=SC1091
 # shellcheck source=./_/husky.sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
 echo "### validate branch name ###"
 npx validate-branch-name
 echo "### lint staged files ###"
-npx --no lint-staged
+npx --no -- lint-staged
 echo "### check for commit mail ###"
 node ./scripts/check-commit-mail.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,6 @@
 echo "### validate branch name ###"
 npx validate-branch-name
 echo "### lint staged files ###"
-npx lint-staged --no
+npx --no lint-staged
 echo "### check for commit mail ###"
 node ./scripts/check-commit-mail.mjs


### PR DESCRIPTION
In general we shouldn't expect `npx` to install the plugins as they should already be installed via `package.json` entries. Elsewhere we wouldn't have full control over reproducible results (e.g. having the same version of that dependency installed), plus a small time optimization that we're able to figure out if some `package.json` entries are missing, which we wouldn't notice on an implicit installation instead (#explicitvsimplicit).