### PR TITLE
refactor: reverted `walk` color change

### DIFF
--- a/tokens/color/transportation.json
+++ b/tokens/color/transportation.json
@@ -14,7 +14,7 @@
 		"airplane": { "value": "{color.turquoise.500.value}" },
 		"taxi": { "value": "{color.yellow.500.value}" },
 		"carsharing": { "value": "{color.orange.500.value}" },
-		"walk": { "value": "{color.cool-gray.200.value}" },
+		"walk": { "value": "{color.cool-gray.400.value}" },
 		"bikesharing": { "value": "{color.red.600.value}" }
 	}
 }


### PR DESCRIPTION
Reverted the change to the `walk` transportation color out of the previous patch release.