### PR TITLE
chore: updated `actions/setup-node`

### DIFF
--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup node equally to our local development version
       # pick the Node version to use and install it
       # https://github.com/actions/setup-node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 


### PR DESCRIPTION
Updated https://github.com/actions/setup-node to a new major version. Mainly the supported minimum Node version has been changed to Node 20.