### PR TITLE
refactor(stylinelint): not lint config on every run

### DIFF
--- a/.config/.lintstagedrc.json
+++ b/.config/.lintstagedrc.json
@@ -1,5 +1,7 @@
 {
 	"*.md": "markdownlint -c .markdown-lint.yml",
-	"*.{css,scss}": "stylelint --fix",
+	".stylelintrc.*": "stylelint --validate --allow-empty-input",
+	"stylelint.config.*": "stylelint --validate --allow-empty-input",
+	"*.{css,scss}": "stylelint --fix --no-validate",
 	"*.{js,ts,tsx}": "xo --fix"
 }

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,3 @@
 build/
 source/_patterns/**
+.stylelintrc.json


### PR DESCRIPTION
In case that we're changing the stylelints configuration files content, we would need to validate it. And elsewhere we don't, compare to https://github.com/stylelint/stylelint/pull/8009