### PR TITLE
refactor(commitlint): Add patterns for patch-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
       patch-dependencies:
         update-types:
           - "patch"
+        patterns:
+          - "*"
       commitlint:
         patterns:
           - "@commitlint*"


### PR DESCRIPTION
currently dependencies aren't grouped anymore (for all named packages). We need to find out, why. This might be related to the patch related group at the beginning.